### PR TITLE
fix: update input and output types in MongoDb.node.ts to NodeConnecti…

### DIFF
--- a/nodes/MongoDb/MongoDb.node.ts
+++ b/nodes/MongoDb/MongoDb.node.ts
@@ -9,6 +9,7 @@ import type {
 	INodeTypeDescription,
 	JsonObject,
 } from 'n8n-workflow';
+import type { NodeConnectionType } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
 import {EJSON} from 'bson';
@@ -46,8 +47,8 @@ export class MongoDb implements INodeType {
 		defaults: {
 			name: 'mongoDb',
 		},
-		inputs: ['main'],
-		outputs: ['main'],
+		inputs: <NodeConnectionType[]>['main'],
+		outputs: <NodeConnectionType[]>['main'],
 		credentials: [
 			{
 				name: 'mongoDb',


### PR DESCRIPTION
This pull request updates the input and output types in the MongoDb.node.ts file to NodeConnectionType[]. The change ensures that the inputs and outputs properties of the node are correctly typed, which resolves type errors related to improper assignment of connection types.